### PR TITLE
✨ Enhance ProfilePage loading state management

### DIFF
--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -2,7 +2,7 @@
 
 import { useSession } from "next-auth/react"
 import { useRouter } from "next/navigation"
-import { useEffect } from "react"
+import { useEffect, useState } from "react"
 import { useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { profileSchema } from "@/lib/validations/profile"
@@ -24,6 +24,7 @@ type FormData = {
 }
 
 export default function ProfilePage() {
+  const [isLoading, setIsLoading] = useState(true)
   const { data: session, status } = useSession()
   const router = useRouter()
   const { name, setUser } = useUserStore()
@@ -42,6 +43,8 @@ export default function ProfilePage() {
   useEffect(() => {
     if (status === "unauthenticated") {
       router.push("/auth/signin")
+    } else if (status === "authenticated") {
+      setIsLoading(false)
     }
   }, [status, router])
 
@@ -86,12 +89,16 @@ export default function ProfilePage() {
     }
   }, [session, form])
 
-  if (status === "loading") {
+  if (status === "loading" || isLoading) {
     return (
       <div className="flex items-center justify-center min-h-screen">
         <Loader2 className="h-8 w-8 animate-spin" />
       </div>
     )
+  }
+
+  if (!session) {
+    return null
   }
 
   return (


### PR DESCRIPTION
- Introduced a loading state using `useState` to manage the rendering of the ProfilePage.
- Updated the `useEffect` hook to set loading state based on authentication status.
- Modified the loading condition to include both session loading and the new loading state.
- Added a null return for unauthenticated users to prevent rendering of the profile content.